### PR TITLE
Update hunspell for darwin to 1.7.

### DIFF
--- a/hunspellgo.go
+++ b/hunspellgo.go
@@ -6,7 +6,7 @@ import (
 )
 
 // #cgo linux LDFLAGS: -L/usr/lib -lhunspell-1.7
-// #cgo darwin LDFLAGS: -lhunspell-1.6 -L/usr/local/lib
+// #cgo darwin LDFLAGS: -lhunspell-1.7 -L/usr/local/lib
 // #cgo darwin CFLAGS: -I/usr/local/include
 // #cgo freebsd CFLAGS: -I/usr/local/include
 // #cgo freebsd LDFLAGS: -L/usr/local/lib -lhunspell-1.3


### PR DESCRIPTION
This is the latest version available via `brew`.